### PR TITLE
Display and render Rockets lists

### DIFF
--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -13,7 +13,17 @@ const Rockets = () => {
   }, [dispatch]); // Added `dispatch` function as a dependency to re-run the effect when it changes.
 
   return (
-    <div>Rockets</div>
+    <section className="rockets-container">
+      {rockets.map((rocket) => (
+        <li className="rocket" key={rocket.id}>
+          <img className="rocket-img" src={rocket.image} alt={rocket.name} />
+          <article className="rocket-info">
+            <h2 className="rocket-name">{rocket.name}</h2>
+            <p className="rocket-description">{rocket.description}</p>
+          </article>
+        </li>
+      ))}
+    </section>
   );
 };
 

--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { fetchRockets } from '../../redux/rockets/rockets';
 
 const Rockets = () => {
-  // `useDispatch` hook to access the `dispatch` function from `react-redux`.
+  // `useDispatch` hook to access the `dispatch` function from `store`.
   const dispatch = useDispatch();
-
+  // `useSelector` hook to get `rockets` data from the `store`.
+  const rockets = useSelector((state) => state.rockets);
   // `useEffect` hook to dispatch the `fetchRockets` action when the component is mounted.
   useEffect(() => {
     dispatch(fetchRockets());

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 
 body {
   margin: 0;
-  font-family: Montserrat, sans-serif;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .App-header {
@@ -56,7 +56,7 @@ nav {
 
 .nav-link {
   color: #2088ff;
-  font-size: 1rem;
+  font-size: 1.1rem;
   font-weight: 500;
   letter-spacing: 1.5px;
   text-decoration: none;
@@ -69,5 +69,37 @@ nav {
 }
 
 main {
-  margin: 6rem;
+  margin: 7.2rem 9rem 4rem;
+}
+
+.rockets-container {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.rocket {
+  display: flex;
+  gap: 2rem;
+}
+
+.rocket-img {
+  box-shadow: 2px 2px 8px 2px #acabab;
+  width: 30%;
+}
+
+.rocket-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.rocket-name {
+  font-weight: 600;
+  letter-spacing: 1px;
+}
+
+.rocket-description {
+  font-weight: inherit;
+  font-size: 1.1rem;
+  letter-spacing: 1.2px;
 }

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -15,7 +15,7 @@ export const fetchRockets = createAsyncThunk(
     const rockets = data.map((rocket) => ({
       id: rocket.rocket_id,
       name: rocket.rocket_name,
-      type: rocket.rocket_type,
+      description: rocket.description,
       image: rocket.flickr_images[0],
     }));
     // Dispatch the action with the payload of the mapped data


### PR DESCRIPTION
## Space Travelers' Hub: Display rockets - Lists render

In this milestone, I implemented the following as per the requirements:

- Use `useSelector()` to select state and render rockets lists in routes.
- Render the list of rockets with the first `flickr_image` as the rocket image.
- Style Rockets section per application design.

## General requirements checklist.

- [X] No linters error.
- [X] Used the correct Gitflow workflow.
- [X] documented work professionally.
- [X] Followed the best practices for JavaScript.