### PR TITLE
Implement rocket booking cancelation - Actions

### DIFF
--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -20,7 +20,11 @@ const Rockets = () => {
           <article className="rocket-info">
             <h2 className="rocket-name">{rocket.name}</h2>
             <p className="rocket-description">{rocket.description}</p>
-            <button className="rocket-reserve-btn" type="button" onClick={() => dispatch(reserveRocket(rocket.id))}>
+            <button
+              className={`rocket-reserve-btn ${rocket.reserved ? 'reserved' : ''}`}
+              type="button"
+              onClick={() => dispatch(reserveRocket(rocket.id))}
+            >
               Reserve Rocket
             </button>
           </article>

--- a/src/index.css
+++ b/src/index.css
@@ -114,3 +114,10 @@ main {
   padding: 10px 15px;
   width: fit-content;
 }
+
+.reserved {
+  color: #767676;
+  border: 1.7px solid #767676;
+  background-color: #fff;
+  cursor: not-allowed;
+}

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -41,7 +41,7 @@ const rocketReducer = (state = initialState, action) => {
     case RESERVE_ROCKET:
       return state.map((rocket) => {
         if (rocket.id !== action.payload) return rocket;
-        return { ...rocket, reserved: true };
+        return { ...rocket, reserved: !rocket.reserved };
       });
     default:
       return state;


### PR DESCRIPTION
## Space Travelers' Hub: Implement rocket booking cancelation

In this milestone, I implemented the following as per the requirements:

- Implemented the rocket booking cancellation with the `Reserve Rocket` button to set the reserved key to false.
- Implemented the toggle classes on reserved key `true` & `false` actions.
- Styled the `Reserve Rockets` button per application UI design.

## General requirements checklist.

- [X] No linters error.
- [X] Used the correct Gitflow workflow.
- [X] documented work professionally.
- [X] Followed the best practices for JavaScript.