### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -1,16 +1,29 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchRockets, reserveRocket } from '../../redux/rockets/rockets';
+import { fetchRockets, reserveRocket, cancelReservation } from '../../redux/rockets/rockets';
 
 const Rockets = () => {
-  // `useDispatch` hook to access the `dispatch` function from `store`.
+  // useDispatch hook to access the dispatch function from store.
   const dispatch = useDispatch();
-  // `useSelector` hook to get `rockets` data from the `store`.
+
+  // useSelector hook to get rockets data from the store.
   const rockets = useSelector((state) => state.rockets);
-  // `useEffect` hook to dispatch the `fetchRockets` action when the component is mounted.
+
+  // `handleReserveRocket` dispatches `reserveRocket` action with selected rocket ID.
+  const handleReserveRocket = (id) => {
+    dispatch(reserveRocket(id));
+  };
+
+  // `handleCancelReservation` dispatches `cancelReservation` action with selected rocket ID.
+  const handleCancelReservation = (id) => {
+    dispatch(cancelReservation(id));
+  };
+
+  // useEffect hook to dispatch the `fetchRockets` action when the component is mounted,
+  // to fetch the list of rockets from the API.
   useEffect(() => {
     dispatch(fetchRockets());
-  }, [dispatch]); // Added `dispatch` function as a dependency to re-run the effect when it changes.
+  });
 
   return (
     <section className="rockets-container">
@@ -23,13 +36,15 @@ const Rockets = () => {
               {rocket.reserved && <span className="rocket-reserve-tag">Reserved</span>}
               {rocket.description}
             </p>
-            <button
-              className={`rocket-reserve-btn ${rocket.reserved ? 'reserved' : ''}`}
-              type="button"
-              onClick={() => dispatch(reserveRocket(rocket.id))}
-            >
-              {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
-            </button>
+            {rocket.reserved ? (
+              <button className="rocket-reserve-btn reserved" type="button" onClick={() => handleCancelReservation(rocket.id)}>
+                Cancel Reservation
+              </button>
+            ) : (
+              <button className="rocket-reserve-btn" type="button" onClick={() => handleReserveRocket(rocket.id)}>
+                Reserve Rocket
+              </button>
+            )}
           </article>
         </li>
       ))}

--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -19,7 +19,10 @@ const Rockets = () => {
           <img className="rocket-img" src={rocket.image} alt={rocket.name} />
           <article className="rocket-info">
             <h2 className="rocket-name">{rocket.name}</h2>
-            <p className="rocket-description">{rocket.description}</p>
+            <p className="rocket-description">
+              {rocket.reserved && <span className="rocket-reserve-tag">Reserved</span>}
+              {rocket.description}
+            </p>
             <button
               className={`rocket-reserve-btn ${rocket.reserved ? 'reserved' : ''}`}
               type="button"

--- a/src/components/pages/Rockets.js
+++ b/src/components/pages/Rockets.js
@@ -28,7 +28,7 @@ const Rockets = () => {
               type="button"
               onClick={() => dispatch(reserveRocket(rocket.id))}
             >
-              Reserve Rocket
+              {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
             </button>
           </article>
         </li>

--- a/src/index.css
+++ b/src/index.css
@@ -105,19 +105,29 @@ main {
   line-height: 1.8rem;
 }
 
+.rocket-reserve-tag {
+  font-size: 0.95rem;
+  line-height: initial;
+  color: #fff;
+  background-color: #18a2b8;
+  padding: 2px 5px;
+  border-radius: 4px;
+  margin-right: 0.8rem;
+}
+
 .rocket-reserve-btn {
   font-size: 0.95rem;
   color: #fff;
   background-color: #007bff;
-  border: none;
+  border: 1.8px solid #007bff;
   border-radius: 4px;
-  padding: 10px 15px;
+  padding: 9px 14px;
   width: fit-content;
 }
 
 .reserved {
   color: #767676;
-  border: 1.7px solid #767676;
+  border: 1.8px solid #767676;
   background-color: #fff;
   cursor: not-allowed;
 }

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -3,46 +3,64 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 // Constants for the action type and API URL
 const FETCH_ROCKETS = 'FETCH_ROCKETS';
 const RESERVE_ROCKET = 'RESERVE_ROCKET';
+const CANCEL_RESERVATION = 'CANCEL_RESERVATION';
 const BASE_API_URL = 'https://api.spacexdata.com/v3/rockets';
 const initialState = [];
 
 // Create the async thunk for fetching the rockets data
 export const fetchRockets = createAsyncThunk(
   FETCH_ROCKETS,
-  async (post, { dispatch }) => {
+  async () => {
     const response = await fetch(BASE_API_URL);
     const data = await response.json();
-    // Map the data to the desired format
-    const rockets = data.map((rocket) => ({
+    // Map the data to the desired format and return the array of rockets
+    return data.map((rocket) => ({
       id: rocket.rocket_id,
       name: rocket.rocket_name,
       description: rocket.description,
       image: rocket.flickr_images[0],
+      reserved: false,
     }));
-    // Dispatch the action with the payload of the mapped data
-    dispatch({
-      type: FETCH_ROCKETS,
-      payload: rockets,
-    });
   },
 );
 
 // Action creator to dispatch the RESERVE_ROCKET action
 export const reserveRocket = (id) => ({
   type: RESERVE_ROCKET,
-  payload: id,
+  id,
 });
 
-// The rocketReducer to handle the FETCH_ROCKETS action
+// Action creator to dispatch the CANCEL_RESERVATION action
+export const cancelReservation = (id) => ({
+  type: CANCEL_RESERVATION,
+  id,
+});
+
+// The rocketReducer to handle the FETCH_ROCKETS and RESERVE_ROCKET actions
 const rocketReducer = (state = initialState, action) => {
   switch (action.type) {
-    case FETCH_ROCKETS:
-      return action.payload;
+    // When the FETCH_ROCKETS action is fulfilled,
+    // return a new state array that combines the previous state and the payload
+    case `${FETCH_ROCKETS}/fulfilled`:
+      return [...state, ...action.payload];
+
+    // When the RESERVE_ROCKET action is dispatched,
+    // map over the state array and update the 'reserved' property of the matc
     case RESERVE_ROCKET:
       return state.map((rocket) => {
-        if (rocket.id !== action.payload) return rocket;
-        return { ...rocket, reserved: !rocket.reserved };
+        if (rocket.id !== action.id) return rocket;
+        return { ...rocket, reserved: true };
       });
+
+    // When the CANCEL_RESERVATION action is dispatched,
+    // map over the state array and update the 'reserved' property of the matching
+    case CANCEL_RESERVATION:
+      return state.map((rocket) => {
+        if (rocket.id !== action.id) return rocket;
+        return { ...rocket, reserved: false };
+      });
+
+    // Return the original state in case of any other action
     default:
       return state;
   }


### PR DESCRIPTION
## Space Travelers' Hub: Switch badges for Rockets

In this milestone, I implemented the following as per the requirements:

- Rockets that have already been reserved should show a `Reserved` badge and a `Cancel reservation` button instead of the default `Reserve rocket` (as per design) using the React `conditional rendering` syntax.
- Styled the `Reserved` badge per application UI design.
- Added `CANCEL_RESERVATION` action and updated rocketReducer to handle `RESERVE_ROCKET` and `CANCEL_RESERVATION` actions
- Refactored Rockets component to handle `reserve/cancel` rocket actions.

## General requirements checklist.

- [X] No linters error.
- [X] Used the correct Gitflow workflow.
- [X] documented work professionally.
- [X] Followed the best practices for JavaScript.